### PR TITLE
Increase timeout to 30 minutes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28,7 +28,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getConfig = exports.ActionOutputs = void 0;
 const core = __importStar(__nccwpck_require__(2186));
-const WORKFLOW_TIMEOUT_SECONDS = 5 * 60;
+const WORKFLOW_TIMEOUT_SECONDS = 30 * 60;
 var ActionOutputs;
 (function (ActionOutputs) {
     ActionOutputs["runId"] = "run_id";

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,6 +1,6 @@
 import * as core from "@actions/core";
 
-const WORKFLOW_TIMEOUT_SECONDS = 5 * 60;
+const WORKFLOW_TIMEOUT_SECONDS = 30 * 60;
 
 /**
  * action.yaml definition.


### PR DESCRIPTION
Have pushed timeout to 30 minutes as sometimes the Cypress tests take a while. Let me know if I have changed it in the wrong place!