### PR TITLE
Prevent internal API retries for timing out action run before input timeout is exceeded

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -235,13 +235,24 @@ export async function getWorkflowRunJobSteps(runId: number): Promise<string[]> {
   }
 }
 
+type RetryOrTimeoutResult<T> = ResultFound<T> | ResultTimeout;
+
+interface ResultFound<T> {
+  timeout: false;
+  value: T;
+}
+
+interface ResultTimeout {
+  timeout: true;
+}
+
 /**
  * Attempt to get a non-empty array from the API.
  */
-export async function retryOrDie<T>(
+export async function retryOrTimeout<T>(
   retryFunc: () => Promise<T[]>,
   timeoutMs: number,
-): Promise<T[]> {
+): Promise<RetryOrTimeoutResult<T[]>> {
   const startTime = Date.now();
   let elapsedTime = 0;
   while (elapsedTime < timeoutMs) {
@@ -249,11 +260,11 @@ export async function retryOrDie<T>(
 
     const response = await retryFunc();
     if (response.length > 0) {
-      return response;
+      return { timeout: false, value: response };
     }
 
     await new Promise<void>((resolve) => setTimeout(resolve, 1000));
   }
 
-  throw new Error("Timed out while attempting to fetch data");
+  return { timeout: true };
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -219,7 +219,7 @@ export async function getWorkflowRunJobSteps(runId: number): Promise<string[]> {
       "Fetched Workflow Run Job Steps:\n" +
         `  Repository: ${config.owner}/${config.repo}\n` +
         `  Workflow Run ID: ${runId}\n` +
-        `  Jobs Fetched: [${jobs.map((job) => job.id).join(", ")}]` +
+        `  Jobs Fetched: [${jobs.map((job) => job.id).join(", ")}]\n` +
         `  Steps Fetched: [${steps.join(", ")}]`,
     );
 
@@ -227,7 +227,7 @@ export async function getWorkflowRunJobSteps(runId: number): Promise<string[]> {
   } catch (error) {
     if (error instanceof Error) {
       core.error(
-        `getWorkflowRunJobs: An unexpected error has occurred: ${error.message}`,
+        `getWorkflowRunJobSteps: An unexpected error has occurred: ${error.message}`,
       );
       core.debug(error.stack ?? "");
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,16 +39,13 @@ async function run(): Promise<void> {
       // Get all runs for a given workflow ID
       const fetchWorkflowRunIds = await api.retryOrTimeout(
         () => api.getWorkflowRunIds(workflowId),
-        WORKFLOW_FETCH_TIMEOUT_MS > timeoutMs
-          ? timeoutMs
-          : WORKFLOW_FETCH_TIMEOUT_MS,
+        Math.max(WORKFLOW_FETCH_TIMEOUT_MS, timeoutMs),
       );
       if (fetchWorkflowRunIds.timeout) {
-        core.debug("Timed out while attempting to fetch Workflow Run IDs");
-        await new Promise((resolve) =>
-          setTimeout(resolve, WORKFLOW_JOB_STEPS_RETRY_MS),
+        core.debug(
+          `Timed out while attempting to fetch Workflow Run IDs, waited ${Date.now() - startTime}ms`,
         );
-        continue;
+        break;
       }
 
       const workflowRunIds = fetchWorkflowRunIds.value;

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,10 +93,11 @@ async function run(): Promise<void> {
       );
     }
 
-    throw new Error("Timeout exceeded while attempting to get Run ID");
+    core.error("Failed: Timeout exceeded while attempting to get Run ID");
+    core.setFailed("Timeout exceeded while attempting to get Run ID");
   } catch (error) {
     if (error instanceof Error) {
-      core.error(`Failed to complete: ${error.message}`);
+      core.error(`Failed: ${error.message}`);
       core.warning("Does the token have the correct permissions?");
       core.debug(error.stack ?? "");
       core.setFailed(error.message);


### PR DESCRIPTION
Fixes: #245 

## Changes

- Refactor `retryOrDie` to `retryOrTimeout`
  - Provide result instead of throwing
- [Backport] Fix some incorrect API logging
- Exit more gracefully instead of throwing to exit for handled failures