### PR TITLE
Filter workflow runs

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -24129,13 +24129,15 @@ async function fetchWorkflowRunUrl(runId) {
     throw error5;
   }
 }
-async function fetchWorkflowRunIds(workflowId, branch) {
+async function fetchWorkflowRunIds(workflowId, branch, startTime) {
   try {
     const useBranchFilter = !branch.isTag && branch.branchName !== void 0 && branch.branchName !== "";
+    const afterStartTime = ">" + new Date(startTime).toISOString();
     const response = await octokit.rest.actions.listWorkflowRuns({
       owner: config.owner,
       repo: config.repo,
       workflow_id: workflowId,
+      created: afterStartTime,
       ...useBranchFilter ? {
         branch: branch.branchName,
         per_page: 10
@@ -24330,7 +24332,7 @@ async function getRunIdAndUrl({
   while (elapsedTime < workflowTimeoutMs) {
     attemptNo++;
     const fetchWorkflowRunIds2 = await retryOrTimeout(
-      () => fetchWorkflowRunIds(workflowId, branch),
+      () => fetchWorkflowRunIds(workflowId, branch, startTime),
       retryTimeout
     );
     if (!fetchWorkflowRunIds2.success) {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -24138,6 +24138,7 @@ async function fetchWorkflowRunIds(workflowId, branch, startTime) {
       repo: config.repo,
       workflow_id: workflowId,
       created: afterStartTime,
+      event: "workflow_dispatch",
       ...useBranchFilter ? {
         branch: branch.branchName,
         per_page: 10

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -358,9 +358,9 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch, Date.now())).resolves.toStrictEqual(
-        mockData.workflow_runs.map((run) => run.id),
-      );
+      await expect(
+        fetchWorkflowRunIds(0, branch, Date.now()),
+      ).resolves.toStrictEqual(mockData.workflow_runs.map((run) => run.id));
 
       // Logging
       assertOnlyCalled(coreDebugLogMock);
@@ -417,7 +417,9 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch, Date.now())).resolves.toStrictEqual([]);
+      await expect(
+        fetchWorkflowRunIds(0, branch, Date.now()),
+      ).resolves.toStrictEqual([]);
 
       // Logging
       assertOnlyCalled(coreDebugLogMock);
@@ -453,7 +455,9 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch, Date.now())).resolves.not.toThrow();
+      await expect(
+        fetchWorkflowRunIds(0, branch, Date.now()),
+      ).resolves.not.toThrow();
       expect(parsedRef).toStrictEqual("master");
 
       // Logging
@@ -490,7 +494,9 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch, Date.now())).resolves.not.toThrow();
+      await expect(
+        fetchWorkflowRunIds(0, branch, Date.now()),
+      ).resolves.not.toThrow();
       expect(parsedRef).toBeUndefined();
 
       // Logging
@@ -527,7 +533,9 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch, Date.now())).resolves.not.toThrow();
+      await expect(
+        fetchWorkflowRunIds(0, branch, Date.now()),
+      ).resolves.not.toThrow();
       expect(parsedRef).toBeUndefined();
 
       // Logging

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -358,7 +358,7 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch)).resolves.toStrictEqual(
+      await expect(fetchWorkflowRunIds(0, branch, Date.now())).resolves.toStrictEqual(
         mockData.workflow_runs.map((run) => run.id),
       );
 
@@ -389,7 +389,7 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch)).rejects.toThrow(
+      await expect(fetchWorkflowRunIds(0, branch, Date.now())).rejects.toThrow(
         `Failed to fetch Workflow runs, expected 200 but received ${errorStatus}`,
       );
 
@@ -417,7 +417,7 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch)).resolves.toStrictEqual([]);
+      await expect(fetchWorkflowRunIds(0, branch, Date.now())).resolves.toStrictEqual([]);
 
       // Logging
       assertOnlyCalled(coreDebugLogMock);
@@ -453,7 +453,7 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch)).resolves.not.toThrow();
+      await expect(fetchWorkflowRunIds(0, branch, Date.now())).resolves.not.toThrow();
       expect(parsedRef).toStrictEqual("master");
 
       // Logging
@@ -490,7 +490,7 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch)).resolves.not.toThrow();
+      await expect(fetchWorkflowRunIds(0, branch, Date.now())).resolves.not.toThrow();
       expect(parsedRef).toBeUndefined();
 
       // Logging
@@ -527,7 +527,7 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch)).resolves.not.toThrow();
+      await expect(fetchWorkflowRunIds(0, branch, Date.now())).resolves.not.toThrow();
       expect(parsedRef).toBeUndefined();
 
       // Logging

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -326,6 +326,7 @@ describe("API", () => {
   });
 
   describe("fetchWorkflowRunIds", () => {
+    const startTimeISO = "2025-06-17T22:24:23.238Z";
     const workflowIdCfg: ActionConfig = {
       token: "secret",
       ref: "/refs/heads/feature_branch",
@@ -359,7 +360,7 @@ describe("API", () => {
 
       // Behaviour
       await expect(
-        fetchWorkflowRunIds(0, branch, Date.now()),
+        fetchWorkflowRunIds(0, branch, startTimeISO),
       ).resolves.toStrictEqual(mockData.workflow_runs.map((run) => run.id));
 
       // Logging
@@ -371,6 +372,7 @@ describe("API", () => {
           Repository: owner/repository
           Branch Filter: true (feature_branch)
           Workflow ID: 0
+          Created: >=2025-06-17T22:24:23.238Z
           Runs Fetched: [0, 1, 2]"
       `,
       );
@@ -389,7 +391,9 @@ describe("API", () => {
       );
 
       // Behaviour
-      await expect(fetchWorkflowRunIds(0, branch, Date.now())).rejects.toThrow(
+      await expect(
+        fetchWorkflowRunIds(0, branch, startTimeISO),
+      ).rejects.toThrow(
         `Failed to fetch Workflow runs, expected 200 but received ${errorStatus}`,
       );
 
@@ -418,7 +422,7 @@ describe("API", () => {
 
       // Behaviour
       await expect(
-        fetchWorkflowRunIds(0, branch, Date.now()),
+        fetchWorkflowRunIds(0, branch, startTimeISO),
       ).resolves.toStrictEqual([]);
 
       // Logging
@@ -430,6 +434,7 @@ describe("API", () => {
           Repository: owner/repository
           Branch Filter: true (feature_branch)
           Workflow ID: 0
+          Created: >=2025-06-17T22:24:23.238Z
           Runs Fetched: []"
       `,
       );
@@ -456,7 +461,7 @@ describe("API", () => {
 
       // Behaviour
       await expect(
-        fetchWorkflowRunIds(0, branch, Date.now()),
+        fetchWorkflowRunIds(0, branch, startTimeISO),
       ).resolves.not.toThrow();
       expect(parsedRef).toStrictEqual("master");
 
@@ -469,6 +474,7 @@ describe("API", () => {
           Repository: owner/repository
           Branch Filter: true (master)
           Workflow ID: 0
+          Created: >=2025-06-17T22:24:23.238Z
           Runs Fetched: []"
       `,
       );
@@ -495,7 +501,7 @@ describe("API", () => {
 
       // Behaviour
       await expect(
-        fetchWorkflowRunIds(0, branch, Date.now()),
+        fetchWorkflowRunIds(0, branch, startTimeISO),
       ).resolves.not.toThrow();
       expect(parsedRef).toBeUndefined();
 
@@ -508,6 +514,7 @@ describe("API", () => {
           Repository: owner/repository
           Branch Filter: false (/refs/tags/1.5.0)
           Workflow ID: 0
+          Created: >=2025-06-17T22:24:23.238Z
           Runs Fetched: []"
       `,
       );
@@ -534,7 +541,7 @@ describe("API", () => {
 
       // Behaviour
       await expect(
-        fetchWorkflowRunIds(0, branch, Date.now()),
+        fetchWorkflowRunIds(0, branch, startTimeISO),
       ).resolves.not.toThrow();
       expect(parsedRef).toBeUndefined();
 
@@ -547,6 +554,7 @@ describe("API", () => {
           Repository: owner/repository
           Branch Filter: false (/refs/cake)
           Workflow ID: 0
+          Created: >=2025-06-17T22:24:23.238Z
           Runs Fetched: []"
       `,
       );

--- a/src/api.ts
+++ b/src/api.ts
@@ -166,14 +166,14 @@ export async function fetchWorkflowRunIds(
       branch.branchName !== undefined &&
       branch.branchName !== "";
 
-    const afterStartTime = ">" + new Date(startTime).toISOString();
+    const createdFrom = ">=" + new Date(startTime).toISOString();
 
     // https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
     const response = await octokit.rest.actions.listWorkflowRuns({
       owner: config.owner,
       repo: config.repo,
       workflow_id: workflowId,
-      created: afterStartTime,
+      created: createdFrom,
       event: "workflow_dispatch",
       ...(useBranchFilter
         ? {
@@ -204,6 +204,7 @@ export async function fetchWorkflowRunIds(
         `  Repository: ${config.owner}/${config.repo}\n` +
         `  Branch Filter: ${branchMsg}\n` +
         `  Workflow ID: ${workflowId}\n` +
+        `  Created: ${createdFrom}\n` +
         `  Runs Fetched: [${runIds.join(", ")}]`,
     );
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -174,6 +174,7 @@ export async function fetchWorkflowRunIds(
       repo: config.repo,
       workflow_id: workflowId,
       created: afterStartTime,
+      event: 'workflow_dispatch',
       ...(useBranchFilter
         ? {
             branch: branch.branchName,

--- a/src/api.ts
+++ b/src/api.ts
@@ -158,6 +158,7 @@ export async function fetchWorkflowRunUrl(runId: number): Promise<string> {
 export async function fetchWorkflowRunIds(
   workflowId: number,
   branch: BranchNameResult,
+  startTime: number,
 ): Promise<number[]> {
   try {
     const useBranchFilter =
@@ -165,11 +166,14 @@ export async function fetchWorkflowRunIds(
       branch.branchName !== undefined &&
       branch.branchName !== "";
 
+    const afterStartTime = '>' + (new Date(startTime)).toISOString();
+
     // https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
     const response = await octokit.rest.actions.listWorkflowRuns({
       owner: config.owner,
       repo: config.repo,
       workflow_id: workflowId,
+      created: afterStartTime,
       ...(useBranchFilter
         ? {
             branch: branch.branchName,

--- a/src/api.ts
+++ b/src/api.ts
@@ -166,7 +166,7 @@ export async function fetchWorkflowRunIds(
       branch.branchName !== undefined &&
       branch.branchName !== "";
 
-    const afterStartTime = '>' + (new Date(startTime)).toISOString();
+    const afterStartTime = ">" + new Date(startTime).toISOString();
 
     // https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
     const response = await octokit.rest.actions.listWorkflowRuns({
@@ -174,7 +174,7 @@ export async function fetchWorkflowRunIds(
       repo: config.repo,
       workflow_id: workflowId,
       created: afterStartTime,
-      event: 'workflow_dispatch',
+      event: "workflow_dispatch",
       ...(useBranchFilter
         ? {
             branch: branch.branchName,

--- a/src/api.ts
+++ b/src/api.ts
@@ -158,7 +158,7 @@ export async function fetchWorkflowRunUrl(runId: number): Promise<string> {
 export async function fetchWorkflowRunIds(
   workflowId: number,
   branch: BranchNameResult,
-  startTime: number,
+  startTimeISO: string,
 ): Promise<number[]> {
   try {
     const useBranchFilter =
@@ -166,7 +166,7 @@ export async function fetchWorkflowRunIds(
       branch.branchName !== undefined &&
       branch.branchName !== "";
 
-    const createdFrom = ">=" + new Date(startTime).toISOString();
+    const createdFrom = `>=${startTimeISO}`;
 
     // https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
     const response = await octokit.rest.actions.listWorkflowRuns({

--- a/src/return-dispatch.ts
+++ b/src/return-dispatch.ts
@@ -151,7 +151,7 @@ export async function getRunIdAndUrl({
 
     // Get all runs for a given workflow ID
     const fetchWorkflowRunIds = await api.retryOrTimeout(
-      () => api.fetchWorkflowRunIds(workflowId, branch),
+      () => api.fetchWorkflowRunIds(workflowId, branch, startTime),
       retryTimeout,
     );
     if (!fetchWorkflowRunIds.success) {

--- a/src/return-dispatch.ts
+++ b/src/return-dispatch.ts
@@ -139,6 +139,7 @@ export async function getRunIdAndUrl({
   workflowTimeoutMs,
   workflowJobStepsRetryMs,
 }: GetRunIdAndUrlOpts): Promise<Result<{ id: number; url: string }>> {
+  const startTimeISO = new Date(startTime).toISOString();
   const retryTimeout = Math.max(
     constants.WORKFLOW_FETCH_TIMEOUT_MS,
     workflowTimeoutMs,
@@ -151,7 +152,7 @@ export async function getRunIdAndUrl({
 
     // Get all runs for a given workflow ID
     const fetchWorkflowRunIds = await api.retryOrTimeout(
-      () => api.fetchWorkflowRunIds(workflowId, branch, startTime),
+      () => api.fetchWorkflowRunIds(workflowId, branch, startTimeISO),
       retryTimeout,
     );
     if (!fetchWorkflowRunIds.success) {


### PR DESCRIPTION
Fixes #264
Also adds a filter `event=workflow_dispatch` to the workflow runs query. This should be safe and not a breaking change, since this action is only ever interested in the workflow_dispatched runs which it itself triggered.

This should reduce the required API calls by a lot, if there are a lot of workflow runs in the target repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workflow run searches now include filtering to only show runs triggered after a specified start time and initiated by manual dispatch events.

- **Bug Fixes**
  - Enhanced workflow run retrieval accuracy by applying filters based on creation time and event type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->