### PR TITLE
Implement etag handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
+    "@octokit/types": "^14.1.0",
     "@opentf/std": "^0.13.0",
     "@total-typescript/ts-reset": "^0.6.1",
     "@types/node": "~20.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@eslint/js':
         specifier: ^9.28.0
         version: 9.28.0
+      '@octokit/types':
+        specifier: ^14.1.0
+        version: 14.1.0
       '@opentf/std':
         specifier: ^0.13.0
         version: 0.13.0
@@ -402,6 +405,9 @@ packages:
   '@octokit/openapi-types@24.2.0':
     resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
 
+  '@octokit/openapi-types@25.1.0':
+    resolution: {integrity: sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==}
+
   '@octokit/plugin-paginate-rest@9.2.2':
     resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
     engines: {node: '>= 18'}
@@ -427,6 +433,9 @@ packages:
 
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  '@octokit/types@14.1.0':
+    resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
 
   '@opentf/std@0.13.0':
     resolution: {integrity: sha512-VG9vn7oML5prxWipDvod1X7z9+3fyyCbw+SuD5F7cWx9F1bXFZdAYGIKGqqHLtfxz3mrXZWHcxnm8d0YwQ7tKQ==}
@@ -2145,6 +2154,8 @@ snapshots:
 
   '@octokit/openapi-types@24.2.0': {}
 
+  '@octokit/openapi-types@25.1.0': {}
+
   '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.1)':
     dependencies:
       '@octokit/core': 5.2.1
@@ -2175,6 +2186,10 @@ snapshots:
   '@octokit/types@13.10.0':
     dependencies:
       '@octokit/openapi-types': 24.2.0
+
+  '@octokit/types@14.1.0':
+    dependencies:
+      '@octokit/openapi-types': 25.1.0
 
   '@opentf/std@0.13.0': {}
 

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -20,7 +20,7 @@ import {
   init,
   retryOrTimeout,
 } from "./api.ts";
-import { clearEtags } from "./etags.js";
+import { clearEtags } from "./etags.ts";
 import { mockLoggingFunctions } from "./test-utils/logging.mock.ts";
 import { getBranchName } from "./utils.ts";
 
@@ -30,7 +30,7 @@ vi.mock("@actions/github");
 interface MockResponse {
   data: any;
   status: number;
-  headers: object;
+  headers: Record<string, string>;
 }
 
 function* mockPageIterator<T, P>(
@@ -615,10 +615,10 @@ describe("API", () => {
       // Behaviour
       // First API call will return 200 with an etag response header
       await fetchWorkflowRunIds(0, branch, startTimeISO);
-      expect(submittedEtag).eq(null);
+      expect(submittedEtag).toStrictEqual(null);
       // Second API call with same parameters should pass the If-None-Match header
       await fetchWorkflowRunIds(0, branch, startTimeISO);
-      expect(submittedEtag).eq(etag);
+      expect(submittedEtag).toStrictEqual(etag);
 
       // Logging
       assertOnlyCalled(coreDebugLogMock);
@@ -671,10 +671,10 @@ describe("API", () => {
       // Behaviour
       // First API call will return 200 with an etag response header
       await fetchWorkflowRunIds(0, branch, startTimeISO);
-      expect(submittedEtag).eq(null);
+      expect(submittedEtag).toStrictEqual(null);
       // Second API call, without If-None-Match header because of different parameters
       await fetchWorkflowRunIds(1, branch, startTimeISO);
-      expect(submittedEtag).eq(null);
+      expect(submittedEtag).toStrictEqual(null);
 
       // Logging
       assertOnlyCalled(coreDebugLogMock);
@@ -846,10 +846,10 @@ describe("API", () => {
       // Behaviour
       // First API call will return 200 with an etag response header
       await fetchWorkflowRunJobSteps(0);
-      expect(submittedEtag).eq(null);
+      expect(submittedEtag).toStrictEqual(null);
       // Second API call with same parameters should pass the If-None-Match header
       await fetchWorkflowRunJobSteps(0);
-      expect(submittedEtag).eq(etag);
+      expect(submittedEtag).toStrictEqual(etag);
 
       // Logging
       assertOnlyCalled(coreDebugLogMock);
@@ -904,10 +904,10 @@ describe("API", () => {
       // Behaviour
       // First API call will return 200 with an etag response header
       await fetchWorkflowRunJobSteps(0);
-      expect(submittedEtag).eq(null);
+      expect(submittedEtag).toStrictEqual(null);
       // Second API call, without If-None-Match header because of different parameters
       await fetchWorkflowRunJobSteps(1);
-      expect(submittedEtag).eq(null);
+      expect(submittedEtag).toStrictEqual(null);
 
       // Logging
       assertOnlyCalled(coreDebugLogMock);

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,6 +2,7 @@ import * as core from "@actions/core";
 import * as github from "@actions/github";
 
 import { type ActionConfig, getConfig } from "./action.ts";
+import { withEtag } from "./etags.js";
 import type { Result } from "./types.ts";
 import { sleep, type BranchNameResult } from "./utils.ts";
 
@@ -168,24 +169,29 @@ export async function fetchWorkflowRunIds(
 
     const createdFrom = `>=${startTimeISO}`;
 
-    // https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
-    const response = await octokit.rest.actions.listWorkflowRuns({
-      owner: config.owner,
-      repo: config.repo,
-      workflow_id: workflowId,
-      created: createdFrom,
-      event: "workflow_dispatch",
-      ...(useBranchFilter
-        ? {
-            branch: branch.branchName,
-            per_page: 10,
-          }
-        : {
-            per_page: 20,
-          }),
-    });
+    const response = await withEtag(
+      "listWorkflowRuns",
+      {
+        owner: config.owner,
+        repo: config.repo,
+        workflow_id: workflowId,
+        created: createdFrom,
+        event: "workflow_dispatch",
+        ...(useBranchFilter
+          ? {
+              branch: branch.branchName,
+              per_page: 10,
+            }
+          : {
+              per_page: 20,
+            }),
+      },
+      async (params) => {
+        // https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
+        return await octokit.rest.actions.listWorkflowRuns(params);
+      },
+    );
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (response.status !== 200) {
       throw new Error(
         `Failed to fetch Workflow runs, expected 200 but received ${response.status}`,
@@ -224,15 +230,20 @@ export async function fetchWorkflowRunJobSteps(
   runId: number,
 ): Promise<string[]> {
   try {
-    // https://docs.github.com/en/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run
-    const response = await octokit.rest.actions.listJobsForWorkflowRun({
-      owner: config.owner,
-      repo: config.repo,
-      run_id: runId,
-      filter: "latest",
-    });
+    const response = await withEtag(
+      "listJobsForWorkflowRun",
+      {
+        owner: config.owner,
+        repo: config.repo,
+        run_id: runId,
+        filter: "latest" as const,
+      },
+      async (params) => {
+        // https://docs.github.com/en/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run
+        return await octokit.rest.actions.listJobsForWorkflowRun(params);
+      },
+    );
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (response.status !== 200) {
       throw new Error(
         `Failed to fetch Workflow Run Jobs, expected 200 but received ${response.status}`,

--- a/src/etags.ts
+++ b/src/etags.ts
@@ -23,7 +23,7 @@ export async function withEtag<T, P extends RequestParameters>(
     paramsWithEtag.headers = {
       "If-None-Match": etag,
       ...(params.headers ?? {}),
-    } as RequestHeaders;
+    } satisfies RequestHeaders;
 
   const response = await requester(paramsWithEtag);
 

--- a/src/etags.ts
+++ b/src/etags.ts
@@ -1,0 +1,68 @@
+import type {
+  RequestHeaders,
+  RequestParameters,
+  OctokitResponse,
+} from "@octokit/types";
+
+interface EtagStoreEntry {
+  etag: string;
+  savedResponse: OctokitResponse<any>;
+}
+
+const etagStore = new Map<string, EtagStoreEntry>();
+
+export async function withEtag<T, P extends RequestParameters>(
+  endpoint: string,
+  params: P,
+  requester: (params: P) => Promise<OctokitResponse<T>>,
+): Promise<OctokitResponse<T>> {
+  const { etag, savedResponse } = getEtag(endpoint, params) ?? {};
+
+  const paramsWithEtag = { ...params };
+  if (etag)
+    paramsWithEtag.headers = {
+      "If-None-Match": etag,
+      ...(params.headers ?? {}),
+    } as RequestHeaders;
+
+  const response = await requester(paramsWithEtag);
+
+  if (
+    response.status === 304 &&
+    etag &&
+    etag === extractEtag(response) &&
+    savedResponse !== undefined
+  ) {
+    return savedResponse;
+  }
+
+  rememberEtag(endpoint, params, response);
+  return response;
+}
+
+function extractEtag(response: OctokitResponse<any>): string | undefined {
+  if ("string" !== typeof response.headers.etag) return;
+  return response.headers.etag.split('"')[1] ?? "";
+}
+
+function getEtag(endpoint: string, params: object): EtagStoreEntry | undefined {
+  return etagStore.get(JSON.stringify({ endpoint, params }));
+}
+
+function rememberEtag(
+  endpoint: string,
+  params: object,
+  response: OctokitResponse<any>,
+): void {
+  const etag = extractEtag(response);
+  if (!etag) return;
+
+  etagStore.set(JSON.stringify({ endpoint, params }), {
+    etag,
+    savedResponse: response,
+  });
+}
+
+export function clearEtags(): void {
+  etagStore.clear();
+}


### PR DESCRIPTION
This is a first attempt to fix #295.
@Codex- please let me know whether this implementation matches how you imagined the solution. I will manually test it with our setup. If you want, I could also write unit tests for the etag file, but the logic should already be tested in the added api test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced ETag-based caching for API requests to improve performance and reduce redundant network calls.

- **Tests**
  - Enhanced test coverage to verify correct handling and caching of ETag headers in API responses.

- **Chores**
  - Added a new development dependency for improved type support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->