### PR TITLE
Update documentation example usage to avoid executing untrusted inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: echo distinct ID ${{ github.event.inputs.distinct_id }}
-        run: echo ${{ github.event.inputs.distinct_id }}
+      - name: echo distinct ID ${{ inputs.distinct_id }}
+        run: echo "${DISTINCT_ID}"
+        env:
+          DISTINCT_ID: ${{ inputs.distinct_id }}
 ```
 
 ## Token


### PR DESCRIPTION
The example shown in the documentation:
https://github.com/Codex-/return-dispatch/blob/16fa9d14771c4d56ae0196bbda1d3c17f7f3650f/README.md?plain=1#L67-L68

Is vulnerable to untrusted input execution (i.e. `distinct_id` _could_ be a malicious command). See [this document](https://securitylab.github.com/resources/github-actions-untrusted-input/) (specifically - `Remediation`) for more details.

Also, the command can be simplified [as `inputs.blah` is equivalent to `github.event.inputs.blah`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#providing-inputs), but [_also_ handles `workflow_call` `inputs`](https://github.blog/changelog/2022-06-09-github-actions-inputs-unified-across-manual-and-reusable-workflows/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow example in README to demonstrate improved handling of workflow inputs using environment variables instead of direct interpolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->